### PR TITLE
Si 2712 enhancement for recursive higher-kinded structures

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -114,7 +114,7 @@ lazy val publishSettings : Seq[Setting[_]] = Seq(
 // VersionUtil.versionPropertiesImpl for details. The standard sbt `version` setting should not be set directly. It
 // is the same as the Maven version and derived automatically from `baseVersion` and `baseVersionSuffix`.
 globalVersionSettings
-baseVersion in Global := "2.11.8-tl-201604181208"
+baseVersion in Global := "2.11.8-pvo-201604231700"
 baseVersionSuffix in Global := ""
 
 lazy val commonSettings = clearSourceAndResourceDirectories ++ publishSettings ++ Seq[Setting[_]](

--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -2225,7 +2225,7 @@ self =>
       if (ofCaseClass && in.token != LPAREN)
         syntaxError(in.lastOffset, "case classes without a parameter list are not allowed;\n"+
                                    "use either case objects or case classes with an explicit `()' as a parameter list.")
-      while (implicitmod == 0 && in.token == LPAREN) {
+      while (in.token == LPAREN) {
         in.nextToken()
         vds += paramClause()
         accept(RPAREN)

--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -2216,7 +2216,9 @@ self =>
         if (in.token == IMPLICIT) {
           in.nextToken()
           implicitmod = Flags.IMPLICIT
-        }
+        } else if (implicitmod != 0)
+          syntaxError(in.lastOffset, "parameter lists following an implicit parameter list must also be implicit")
+
         commaSeparated(param(owner, implicitmod, caseParam  ))
       }
       val vds = new ListBuffer[List[ValDef]]

--- a/src/compiler/scala/tools/nsc/ast/parser/TreeBuilder.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/TreeBuilder.scala
@@ -129,7 +129,7 @@ abstract class TreeBuilder {
       def makeEvidenceParam(tpt: Tree) = ValDef(mods | IMPLICIT | SYNTHETIC, freshTermName(nme.EVIDENCE_PARAM_PREFIX), tpt, EmptyTree)
       val evidenceParams = contextBounds map makeEvidenceParam
 
-      val (prefix, suffix) = vparamss.span(_.headOption.map(!_.mods.hasFlag(IMPLICIT)).getOrElse(false))
+      val (prefix, suffix) = vparamss.span(_.headOption.map(!_.mods.hasFlag(IMPLICIT)).getOrElse(true))
       prefix ::: (suffix match {
         case is :: iss => List(evidenceParams ::: is) ::: iss
         case Nil => List(evidenceParams)

--- a/src/compiler/scala/tools/nsc/ast/parser/TreeBuilder.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/TreeBuilder.scala
@@ -129,11 +129,11 @@ abstract class TreeBuilder {
       def makeEvidenceParam(tpt: Tree) = ValDef(mods | IMPLICIT | SYNTHETIC, freshTermName(nme.EVIDENCE_PARAM_PREFIX), tpt, EmptyTree)
       val evidenceParams = contextBounds map makeEvidenceParam
 
-      val vparamssLast = if(vparamss.nonEmpty) vparamss.last else Nil
-      if(vparamssLast.nonEmpty && vparamssLast.head.mods.hasFlag(IMPLICIT))
-        vparamss.init ::: List(evidenceParams ::: vparamssLast)
-      else
-        vparamss ::: List(evidenceParams)
+      val (prefix, suffix) = vparamss.span(_.headOption.map(!_.mods.hasFlag(IMPLICIT)).getOrElse(false))
+      prefix ::: (suffix match {
+        case is :: iss => List(evidenceParams ::: is) ::: iss
+        case Nil => List(evidenceParams)
+      })
     }
   }
 

--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -1254,7 +1254,6 @@ trait Infer extends Checkable {
       def isFreeTypeParamOfTerm(sym: Symbol) = (
         sym.isAbstractType
           && sym.owner.isTerm
-          && !sym.info.bounds.exists(_.typeParams.nonEmpty)
         )
 
       // Intentionally *not* using `Type#typeSymbol` here, which would normalize `tp`

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -3067,6 +3067,7 @@ trait Types
         } else false
       }
 
+
       /*  Full case: involving a check of the form
        *  {{{
        *    TC1[T1,..., TN] <: TC2[T'1,...,T'N]
@@ -3075,6 +3076,17 @@ trait Types
        *  type parameter we're trying to infer (the result will be sanity-checked later).
        */
       def unifyFull(tpe: Type): Boolean = {
+        /*
+         * is this type higher-kinded?
+         */
+        def isHK(tp: Type): Boolean = tp.typeArgs.length > 0
+
+        /*
+         * a function (that might not be exact) to determine whether unifySpecificRec shall be tried
+         */
+        def reqHKRecUni(tp: Type, rightToLeft: Boolean): Boolean =
+          tp.typeArgs.find(isHK).isDefined
+          
         def unifySpecific(tp: Type) = {
           if(sameLength(typeArgs, tp.typeArgs)) {
             val lhs = if (isLowerBound) tp.typeArgs else typeArgs
@@ -3096,35 +3108,172 @@ trait Types
             //
             // A more "natural" unifier might be M[t] = [t][t => t]. There's lots of scope for
             // experimenting with alternatives here.
-
             val tpSym = tp.typeSymbolDirect
             val rightToLeft = tpSym.annotations.exists(_ matches definitions.unifyRightToLeftClass)
 
-            val numAbstracted = typeArgs.length
+            val numAbstracted = typeArgs.length            
             val numCaptured = tp.typeArgs.length-numAbstracted
-            val (captured, abstracted) =
-              if(rightToLeft) tp.typeArgs.splitAt(numAbstracted).swap
-             else tp.typeArgs.splitAt(numCaptured)
 
-            val lhs = if (isLowerBound) abstracted else typeArgs
-            val rhs = if (isLowerBound) typeArgs else abstracted
-            // This is a higher-kinded type var with same arity as tp.
-            // If so (see SI-7517), side effect: adds the type constructor itself as a bound.
-            isSubArgs(lhs, rhs, params, AnyDepth) && {
+            // checks whether it can be subject to recursive SI2712 HK unification
+            // M[t] = [t][Int => t] => classic SI2712 patch
+            // M[t] = [t][(Option[t], String, List[t])] => recursive SI2712 unification
+            if(!reqHKRecUni(tp, rightToLeft)) {
+              // NORMAL SI2712 UNIFICATION
+              val (captured, abstracted) =
+                if(rightToLeft) tp.typeArgs.splitAt(numAbstracted).swap
+               else tp.typeArgs.splitAt(numCaptured)
+
+              val lhs = if (isLowerBound) abstracted else typeArgs
+              val rhs = if (isLowerBound) typeArgs else abstracted
+              // This is a higher-kinded type var with same arity as tp.
+              // If so (see SI-7517), side effect: adds the type constructor itself as a bound.
+              isSubArgs(lhs, rhs, params, AnyDepth) && {
+                val absSyms =
+                  if(rightToLeft) tpSym.typeParams.take(numAbstracted)
+                  else tpSym.typeParams.drop(numCaptured)
+                val freeSyms = absSyms.map(_.cloneSymbol(tpSym))
+                val args =
+                  if(rightToLeft) freeSyms.map(_.tpeHK) ++ captured
+                  else captured ++ freeSyms.map(_.tpeHK)
+                val poly = PolyType(freeSyms, appliedType(tp.typeConstructor, args))
+                addBound(poly)
+                true
+              }
+            } else {
+              // RECURSIVE SI2712 UNIFICATION
+              // println(s"#### START $tp ${tp.typeArgs}")
+
+              // creates freesyms first
               val absSyms =
                 if(rightToLeft) tpSym.typeParams.take(numAbstracted)
                 else tpSym.typeParams.drop(numCaptured)
               val freeSyms = absSyms.map(_.cloneSymbol(tpSym))
-              val args =
-                if(rightToLeft) freeSyms.map(_.tpeHK) ++ captured
-                else captured ++ freeSyms.map(_.tpeHK)
-              val poly = PolyType(freeSyms, appliedType(tp.typeConstructor, args))
-              addBound(poly)
-              true
+
+              // for each typearg, try to unify in depth using previous free symbols
+              val unifiedTypesBuider = List.newBuilder[Type]
+              // stops at first error, no need to do more work than needed
+              tp.typeArgs.takeWhile { tpp =>
+                val (isUnifiable, tpu) = unifySpecificRec(tpp, freeSyms)
+                if(isUnifiable) unifiedTypesBuider += tpu
+                isUnifiable
+              }
+              val unifiedTypes = unifiedTypesBuider.result()
+              // if all types are unifiable, build final unified poly type
+              if(unifiedTypes.length == tp.typeArgs.length) {
+                val poly = PolyType(freeSyms, appliedType(tp.typeConstructor, unifiedTypes))
+                // println(s"#### Unified tp:$tp to $poly")
+                addBound(poly)
+                true
+              } else {
+                // println(s"#### Unified failed $unifiedTypes")
+                false
+              }
+
             }
           } else
             false
         }
+
+        /*
+         * This is the recursive SI2712 unification function (can only be called in settings.YhigherOrderUnification)
+         * It's very simple:
+         *   - same typeargs length => just apply freesymbols to tp
+         *   - no type args => no need to unify anything, just keep it
+         *   - higher-kinded => tries to unify by SI2712 or if needed, launch another deeper  SI2712 recursive unification
+         */
+        def unifySpecificRec(tp: Type, freeSyms: List[Symbol]): (Boolean, Type) = {
+          // println(s"START $tp $freeSyms")
+          // same typeargs length => just apply freesymbols to tp
+          if(sameLength(typeArgs, tp.typeArgs)) {
+            val lhs = if (isLowerBound) tp.typeArgs else typeArgs
+            val rhs = if (isLowerBound) typeArgs else tp.typeArgs
+            // This is a higher-kinded type var with same arity as tp.
+            // If so (see SI-7517), side effect: adds the type constructor itself as a bound.
+            //isSubArgs(lhs, rhs, params, AnyDepth) && { addBound(tp.typeConstructor); true }
+            val r = isSubArgs(lhs, rhs, params, AnyDepth) -> appliedType(tp.typeConstructor, freeSyms.map(_.tpeHK))
+            // println(s"END same length $r")
+            r
+          } 
+          // no tp's type args => no need to unify anything, just keep it as is
+          else if(tp.typeArgs.lengthCompare(0) == 0) {
+            val r = true -> tp
+            // println(s"END nothing $r")
+            r
+          }
+          // higher-kinded => tries to unify by SI2712 or if needed, launch another deeper  SI2712 recursive unification
+          else if(typeArgs.lengthCompare(0) > 0 && compareLengths(typeArgs, tp.typeArgs) < 0) {
+            // Simple algorithm as suggested by Paul Chiusano in the comments on SI-2712
+            //
+            //   https://issues.scala-lang.org/browse/SI-2712?focusedCommentId=61270
+            //
+            // Treat the type constructor as curried and partially applied, we treat a prefix
+            // as constants and solve for the suffix. For the example in the ticket, unifying
+            // M[A] with Int => Int this unifies as,
+            //
+            //   M[t] = [t][Int => t]
+            //   A = Int
+            //
+            // A more "natural" unifier might be M[t] = [t][t => t]. There's lots of scope for
+            // experimenting with alternatives here.
+            val tpSym = tp.typeSymbolDirect
+            val rightToLeft = tpSym.annotations.exists(_ matches definitions.unifyRightToLeftClass)
+
+            if(!reqHKRecUni(tp, rightToLeft)) {
+              // NORMAL CASE without recursion
+              val numAbstracted = typeArgs.length
+              val numCaptured = tp.typeArgs.length-numAbstracted
+              val (captured, abstracted) =
+                if(rightToLeft) tp.typeArgs.splitAt(numAbstracted).swap
+               else tp.typeArgs.splitAt(numCaptured)
+
+              val lhs = if (isLowerBound) abstracted else typeArgs
+              val rhs = if (isLowerBound) typeArgs else abstracted
+              // This is a higher-kinded type var with same arity as tp.
+              // If so (see SI-7517), side effect: adds the type constructor itself as a bound.
+              val r = isSubArgs(lhs, rhs, params, AnyDepth) -> {                
+                val args =
+                  if(rightToLeft) freeSyms.map(_.tpeHK) ++ captured
+                  else captured ++ freeSyms.map(_.tpeHK)
+                appliedType(tp.typeConstructor, args)
+              }
+              // println(s"END classic $r")
+              r
+
+            } else {
+              val unifiedTypesBuider = List.newBuilder[Type]
+              tp.typeArgs.takeWhile { tpp =>
+                // typearg is HK, so go in it              
+                if(isHK(tpp)) {
+                  val (isUnified, tpu) = unifySpecificRec(tpp, freeSyms)
+                  if(isUnified) unifiedTypesBuider += tpu
+                  isUnified
+                // not HK, so ok anyway
+                } else {
+                  unifiedTypesBuider += tpp
+                  true
+                }
+              }
+
+              val unifiedTypes = unifiedTypesBuider.result()
+
+              // all type args are unifiable, apply them to tp
+              if(unifiedTypes.length == tp.typeArgs.length) {
+                val r = (true, appliedType(tp.typeConstructor, unifiedTypes))
+                // println(s"END HK $r")
+                r
+              }
+              // some type args are NOT unifiable, return false
+              else {
+                val r = (false, tp)
+                // println(s"END not unifiable $r")
+                r
+              }
+            }
+            
+          } else
+            (false, tp)
+        }
+
         // The type with which we can successfully unify can be hidden
         // behind singleton types and type aliases.
         tpe.dealiasWidenChain exists unifySpecific

--- a/test/files/neg/multi-implicits.check
+++ b/test/files/neg/multi-implicits.check
@@ -1,0 +1,4 @@
+multi-implicits.scala:30: error: parameter lists following an implicit parameter list must also be implicit
+  def run[T: Baz](t: T)(implicit foo: Foo[T])(bar: Bar[foo.A]): bar.B = bar.value
+                                              ^
+one error found

--- a/test/files/neg/multi-implicits.scala
+++ b/test/files/neg/multi-implicits.scala
@@ -27,11 +27,5 @@ object Test {
     implicit def baz[T]: Baz[T] = new Baz[T] {}
   }
 
-  def run[T: Baz](t: T)(implicit foo: Foo[T])(implicit bar: Bar[foo.A]): bar.B = bar.value
-
-  val value = run(23)
-  assert(value: Boolean)
-
-  val value2 = run(23)(Baz.baz, Foo.fooIS)(Bar.barSB)
-  assert(value: Boolean)
+  def run[T: Baz](t: T)(implicit foo: Foo[T])(bar: Bar[foo.A]): bar.B = bar.value
 }

--- a/test/files/pos/hkgadt.scala
+++ b/test/files/pos/hkgadt.scala
@@ -1,0 +1,18 @@
+package test
+
+object HKGADT {
+  sealed trait Foo[F[_]]
+  final case class Bar() extends Foo[List]
+
+  def frob[F[_]](foo: Foo[F]): F[Int] =
+    foo match {
+      case Bar() =>
+         List(1)
+    }
+
+  sealed trait Foo1[F]
+  final case class Bar1() extends Foo1[Int]
+  def frob1[A](foo: Foo1[A]) = foo match {
+    case Bar1() => 1
+  }
+}

--- a/test/files/pos/hkgadt.scala
+++ b/test/files/pos/hkgadt.scala
@@ -12,7 +12,7 @@ object HKGADT {
 
   sealed trait Foo1[F]
   final case class Bar1() extends Foo1[Int]
-  def frob1[A](foo: Foo1[A]) = foo match {
+  def frob1[A](foo: Foo1[A]): A = foo match {
     case Bar1() => 1
   }
 }

--- a/test/files/pos/multi-implicits.scala
+++ b/test/files/pos/multi-implicits.scala
@@ -1,0 +1,29 @@
+package test
+
+object Test {
+  // A couple of type classes with type members ...
+  trait Foo[T] {
+    type A
+  }
+
+  object Foo {
+    implicit val fooIS = new Foo[Int] { type A = String }
+  }
+
+  trait Bar[T] {
+    type B
+    val value: B
+  }
+
+  object Bar {
+    implicit val barSB = new Bar[String] {
+      type B = Boolean
+      val value = true
+    }
+  }
+
+  def run[T](t: T)(implicit foo: Foo[T])(bar: Bar[foo.A]): bar.B = bar.value
+
+  val value = run(23)
+  assert(value: Boolean)
+}

--- a/test/files/pos/multi-implicits.scala
+++ b/test/files/pos/multi-implicits.scala
@@ -34,4 +34,28 @@ object Test {
 
   val value2 = run(23)(Baz.baz, Foo.fooIS)(Bar.barSB)
   assert(value: Boolean)
+
+  def boundNullary[T: Baz] = ()
+  boundNullary[Int]
+  boundNullary[Int](Baz.baz)
+
+  def boundEmpty[T: Baz]() = ()
+  boundEmpty[Int]()
+  boundEmpty[Int]()(Baz.baz)
+
+  def boundExplicit[T: Baz](i: T) = ()
+  boundExplicit(23)
+  boundExplicit[Int](23)(Baz.baz)
+
+  def boundImplicit[T: Baz](implicit fooT: Foo[T]) = ()
+  boundImplicit[Int]
+  boundImplicit[Int](Baz.baz, Foo.fooIS)
+
+  def boundExplicitImplicit[T: Baz](i: T)(implicit fooT: Foo[T]) = ()
+  boundExplicitImplicit(23)
+  boundExplicitImplicit[Int](23)(Baz.baz, Foo.fooIS)
+
+  def boundEmptyImplicit[T: Baz]()(implicit fooT: Foo[T]) = ()
+  boundEmptyImplicit[Int]()
+  boundEmptyImplicit[Int]()(Baz.baz, Foo.fooIS)
 }

--- a/test/files/pos/t2712-8.flags
+++ b/test/files/pos/t2712-8.flags
@@ -1,0 +1,1 @@
+-Yhigher-order-unification

--- a/test/files/pos/t2712-8.scala
+++ b/test/files/pos/t2712-8.scala
@@ -1,0 +1,30 @@
+package test
+
+object HK {
+  sealed trait Coproduct
+  @scala.annotation.unifyRightToLeft
+  sealed trait :+:[+H, +T <: Coproduct] extends Coproduct
+  sealed trait CNil extends Coproduct
+
+  trait NaturalTransformation[F[_], G[_]]
+  type ~>[F[_], G[_]] = NaturalTransformation[F, G]
+
+  def foo[F[_], G[_]](f: F ~> G): Unit = ???
+
+  type Id[A] = A
+
+  trait Bar[A, B, C]
+  val a: ({type λ[T] = Bar[Int, String, T] })#λ ~> Id = ???
+  foo(a)
+
+  val b: ({type λ[T] = T :+: CNil })#λ ~> Id = ???
+  foo(b)
+
+  val c : ({type λ[T] = Option[T] :+: String :+: List[T] :+: Bar[Int, String, T] :+: CNil })#λ ~> Id = ???
+  foo(c)
+
+  def foo2[F[_], A](t: F[A]): Unit = ???
+  foo2((List(4), "toto", new Bar[Boolean, String, Int] {}))
+  val d: (Option[Int], List[Int], String, Bar[Boolean, String, Int]) = (Some(5), List(4), "toto", new Bar[Boolean, String, Int] {})
+  foo2(d)
+}


### PR DESCRIPTION
With current patch,

you can unify 

```
F[T] <=> Bar[Int, String, T]
F[T] <=> (Int => T)
```

but not:

```
F[T] <=> Option[String, Bar[Int, String, T]]
F[T] <=> Option[List[T], Bar[Int, String, T]]
```

At first view, it should be possible (using the same left-right precedences rules)

This patch is aimed at solving this issue by introspecting recursively higher-kinded structures in depth trying to unify every internal structure with `F[T]`.

It's just another case tried when basic solution doesn't work so all existing tests work.
And it allows to compile straight-forward this kind of code:

```
// Shapeless Coproduct
sealed trait Coproduct
@scala.annotation.unifyRightToLeft
sealed trait :+:[+H, +T <: Coproduct] extends Coproduct
sealed trait CNil extends Coproduct

// cats/scalaz TransNat
trait NaturalTransformation[F[_], G[_]]
type ~>[F[_], G[_]] = NaturalTransformation[F, G]

// a function using trans-nat (like fold in Free)
def foo[F[_], G[_]](f: F ~> G): Unit = ???

type Id[A] = A

trait Bar[A, B, C]
val a: ({type λ[T] = Bar[Int, String, T] })#λ ~> Id = ???
foo(a)

val b: ({type λ[T] = T :+: CNil })#λ ~> Id = ???
foo(b)

val c : ({type λ[T] = Option[T] :+: String :+: List[T] :+: Bar[Int, String, T] :+: CNil })#λ ~> Id = ???
foo(c)
```

... Which might change a lot how we can manipulate multi-higher-kinded structures like Free or Coproducts in our libs and code...
